### PR TITLE
components cannot go below window

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -242,3 +242,11 @@ or
         - *optional*
     - `suffix`
         - *optional*
+
+
+## KwcNumberInputCommon Mixin
+
+Add common functionality for the components here such as positioning checks. Add to your component like so:
+```
+class NewKwcNumberInput extends KwcNumberInputCommon(PolymerElement) {...}
+```

--- a/kwc-dial-numpad.js
+++ b/kwc-dial-numpad.js
@@ -2,8 +2,9 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import './kwc-dial.js';
 import './kwc-numpad.js';
+import { KwcNumberInputCommon } from './kwc-number-input-common.js';
 
-class KwcDialNumpad extends PolymerElement {
+class KwcDialNumpad extends KwcNumberInputCommon(PolymerElement) {
     static get template() {
         return html`
             <style>
@@ -55,6 +56,7 @@ class KwcDialNumpad extends PolymerElement {
     connectedCallback() {
         super.connectedCallback();
         this.attachListeners();
+        this.checkPagePosition();
     }
 
     disconnectedCallback() {

--- a/kwc-dial-slider.js
+++ b/kwc-dial-slider.js
@@ -2,8 +2,9 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import './kwc-slider.js';
 import './kwc-dial.js';
+import { KwcNumberInputCommon } from './kwc-number-input-common.js';
 
-class KwcDialSlider extends PolymerElement {
+class KwcDialSlider extends KwcNumberInputCommon(PolymerElement) {
     static get template() {
         return html`
             <style>
@@ -62,6 +63,7 @@ class KwcDialSlider extends PolymerElement {
         super.connectedCallback();
         this.attachListeners();
         this.applyRange();
+        this.checkPagePosition();
     }
 
     disconnectedCallback() {

--- a/kwc-dial.js
+++ b/kwc-dial.js
@@ -1,8 +1,9 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@polymer/polymer/lib/elements/custom-style.js';
+import { KwcNumberInputCommon } from './kwc-number-input-common.js';
 
-class KwcDial extends PolymerElement {
+class KwcDial extends KwcNumberInputCommon(PolymerElement) {
     static get template() {
         return html`
             <style>
@@ -219,6 +220,7 @@ class KwcDial extends PolymerElement {
     connectedCallback() {
         super.connectedCallback();
         this.attachListeners();
+        this.checkPagePosition();
     }
 
     disconnectedCallback() {

--- a/kwc-number-input-common.js
+++ b/kwc-number-input-common.js
@@ -1,0 +1,10 @@
+export const KwcNumberInputCommon = base => class extends base {
+    checkPagePosition() {
+        if (this.parentElement && this.parentElement.offsetTop > window.innerHeight - this.clientHeight) {
+            this.style.transform = "translateY(-110%)";
+            this.style.webkitTransform = "translateY(-110%)";
+        }
+    }
+}
+
+export default KwcNumberInputCommon;

--- a/kwc-numpad.js
+++ b/kwc-numpad.js
@@ -2,8 +2,9 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@polymer/polymer/lib/elements/custom-style.js';
 import { backspaceIcon } from './assets.js';
+import { KwcNumberInputCommon } from './kwc-number-input-common.js';
 
-class KwcNumpad extends PolymerElement {
+class KwcNumpad extends KwcNumberInputCommon(PolymerElement) {
     static get template() {
         return html`
             <style>
@@ -119,6 +120,7 @@ class KwcNumpad extends PolymerElement {
         super.connectedCallback();
         this.updateResult = this.updateResult.bind(this);
         this.attachListeners();
+        this.checkPagePosition();
     }
     disconnectedCallback() {
         super.disconnectedCallback();

--- a/kwc-slider-numpad.js
+++ b/kwc-slider-numpad.js
@@ -2,8 +2,9 @@ import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import './kwc-slider.js';
 import './kwc-numpad.js';
+import { KwcNumberInputCommon } from './kwc-number-input-common.js';
 
-class KwcSliderNumpad extends PolymerElement {
+class KwcSliderNumpad extends KwcNumberInputCommon(PolymerElement) {
     static get template() {
         return html`
             <style>
@@ -51,6 +52,7 @@ class KwcSliderNumpad extends PolymerElement {
         super.connectedCallback();
         this.attachListeners();
         this.applyRange();
+        this.checkPagePosition();
     }
 
     disconnectedCallback() {

--- a/kwc-slider.js
+++ b/kwc-slider.js
@@ -1,8 +1,9 @@
 import { PolymerElement } from '@polymer/polymer/polymer-element.js';
 import { html } from '@polymer/polymer/lib/utils/html-tag.js';
 import '@polymer/polymer/lib/elements/custom-style.js';
+import { KwcNumberInputCommon } from './kwc-number-input-common.js';
 
-class KwcSlider extends PolymerElement {
+class KwcSlider extends KwcNumberInputCommon(PolymerElement) {
     static get template() {
         return html`
             <style>
@@ -99,6 +100,7 @@ class KwcSlider extends PolymerElement {
         super.connectedCallback();
         this.attachListeners();
         this.applyMax();
+        this.checkPagePosition();
     }
 
     disconnectedCallback() {


### PR DESCRIPTION
Added a common class to the number picker components to more easily add functions to all elements.

The components now cannot go below the window.